### PR TITLE
Better function argument checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,14 @@ valve.validate(
 #### Checking with a list
 
 The `check` list outlines what the arguments passed in should look like. The example above uses a list to validate that exactly one string is passed to `foo`. Each element in the list is an argument type:
+* `column`: a column in the target table (the `table` column of the rule or field table)
 * `expression`: function or datatype
-* `field`: a table-column pair
+* `field`: a table-column pair where the table is in the inputs and the column is in the table
 * `named:...`: named argument followed by the argument key (e.g., if your named arg looks like `distinct=true`, then this value will be `named:distinct`)
-* `regex`: a regex pattern or substitution
+* `regex_match`: a regex pattern
+* `regex_sub`: a regex substitution
 * `string`: any other string
+* `tree`: a defined treename (table-column pair)
 
 If an argument can be of multiple types, you can join them with ` or `. For example, for an argument that can be either a string or a field: `string or field`.
 
@@ -159,31 +162,35 @@ For example, if you expect one or more string arguments: `string*`. Named argume
 
 #### Checking with a function
 
-You can also define your own function to check the arguments passed to your custom VALVE function. This function needs two parameters:
+Lists do not allow you to check dependencies between arguments, so it may be beneficial to define your own `check` function. This function must have four parameters (but not all need to be used):
 * `config`: VALVE configuration dictionary
+* `table`: the target table that the function will be run in
+* `column`: the target column that the function will be run in
 * `args`: a list of parsed args passed to the function
 
-The function should return a string error message if any error was found, otherwise, it should return `None`. The custom functions are useful for when you want to validate more than just the structure, for example, if you expect exactly one table name:
+The function should return a string error message if any error was found, otherwise, it should return `None`. The custom functions are useful for when you want to validate more than just the structure, for example, if you expect two values that are tables other than the target table:
 ```python
 def validate_foo(config, args, table, column, row_idx, value):
     ...
 
-def check_foo(config, args):
-    if len(args) > 1:
-        # more than one arguments were passed
-        return "foo expects one argument"
-    if args[0]["type"] != "string":
-        # the argument is not a string
-        return "foo argument 1 must be of type 'string'"
-    if args[0]["value"] not in config["table_details"]:
-        # the argument is not a valid table name
-        return "foo argument 1 must be a table name from inputs"
+def check_foo(config, table, column, args):
+    i = 1
+    for a in args:
+        if i == 2:
+            return f"foo expects 2 arguments, but {len(args)} were given"
+        if a["type"] != "string":
+            return f"foo argument {i} must be a string representing a table"
+        if a["value"] == table:
+            return f"foo argument {i} must not be '{table}'"
+        if a["value"] not in config["table_details"]:
+            return f"foo argument {i} must be a table in inputs other than '{table}'"
+        i += 1
 
 valve.validate(
     "inputs/",
     functions={
         "foo": {
-            "usage": "foo(table)",
+            "usage": "foo(string, string)",
             "check": check_foo,
             "validate": validate_foo
         }

--- a/valve/valve.py
+++ b/valve/valve.py
@@ -396,12 +396,12 @@ def configure_rules(config):
         when_condition = row["when condition"]
         parsed_when_condition, err = parse_condition(config, when_condition)
         if err:
-            messages.append(error(config, "field", "when condition", row_idx, err))
+            messages.append(error(config, "rule", "when condition", row_idx, err))
             continue
         then_condition = row["then condition"]
         parsed_then_condition, err = parse_condition(config, then_condition)
         if err:
-            messages.append(error(config, "field", "then condition", row_idx, err))
+            messages.append(error(config, "rule", "then condition", row_idx, err))
             continue
 
         # Add this condition to the dicts
@@ -543,7 +543,7 @@ def check_args(name, args, expected):
             e = e[:-1]
             for a in args[i:]:
                 if not check_arg(a, e):
-                    errors.append(f"{name} optional argument {i + 1} must be of type {e}{add_msg}")
+                    errors.append(f"optional argument {i + 1} must be of type {e}{add_msg}")
                 i += 1
         elif e.endswith("?"):
             # zero or one
@@ -558,34 +558,34 @@ def check_args(name, args, expected):
                     continue
                 except StopIteration:
                     # no other expected args, add error
-                    errors.append(f"{name} optional argument {i + 1} must be of type {e}{add_msg}")
+                    errors.append(f"optional argument {i + 1} must be of type {e}{add_msg}")
                     break
         elif e.endswith("+"):
             # one or more
             e = e[:-1]
             if len(args) <= i:
-                errors.append(f"{name} requires one or more {e}{add_msg} at argument {i + 1}")
+                errors.append(f"requires one or more {e}{add_msg} at argument {i + 1}")
                 break
             for a in args[i:]:
                 if not check_arg(a, e):
-                    errors.append(f"{name} argument {i + 1} must be of type {e}{add_msg}")
+                    errors.append(f"argument {i + 1} must be of type {e}{add_msg}")
                 i += 1
         else:
             # exactly one
             if len(args) <= i:
-                errors.append(f"{name} requires one {e}{add_msg} at argument {i + 1}")
+                errors.append(f"requires one {e}{add_msg} at argument {i + 1}")
                 break
             if not check_arg(args[i], e):
-                errors.append(f"{name} argument {i + 1} must be of type {e}{add_msg}")
+                errors.append(f"argument {i + 1} must be of type {e}{add_msg}")
         try:
             i += 1
             e = next(itr)
         except StopIteration:
             break
     if i < len(args):
-        errors.append(f"{name} expects {i} argument(s), but {len(args)} were given")
+        errors.append(f"expects {i} argument(s), but {len(args)} were given")
     if errors:
-        return "; ".join(errors)
+        return name + " " + "; ".join(errors)
 
 
 def check_arg(arg, expected):

--- a/valve/valve.py
+++ b/valve/valve.py
@@ -533,11 +533,8 @@ def check_args(name, args, expected):
     errors = []
     itr = iter(expected)
     e = next(itr)
-    other_e = None
+    add_msg = ""
     while True:
-        add_msg = ""
-        if other_e:
-            add_msg = f" or {other_e}"
         if e.endswith("*"):
             # zero or more
             e = e[:-1]
@@ -553,7 +550,7 @@ def check_args(name, args, expected):
                 break
             if not check_arg(args[i], e):
                 try:
-                    other_e = e
+                    add_msg = f" or {e}"
                     e = next(itr)
                     continue
                 except StopIteration:


### PR DESCRIPTION
Instead of passing a function name to `check`, I propose we pass a list of the expected structure.

One example is if you pass the old args to lookup:
```
lookup(table.column, table2.column2)
```

Results in:
> lookup argument 1 must be of type string; argument 2 must be of type string; requires one string at argument 3

---

#### Checking with a list

The `check` list outlines what the arguments passed in should look like. The example above uses a list to validate that exactly one string is passed to `foo`. Each element in the list is an argument type:
* `column`: a column in the target table (the `table` column of the rule or field table)
* `expression`: function or datatype
* `field`: a table-column pair where the table is in the inputs and the column is in the table
* `named:...`: named argument followed by the argument key (e.g., if your named arg looks like `distinct=true`, then this value will be `named:distinct`)
* `regex_match`: a regex pattern
* `regex_sub`: a regex substitution
* `string`: any other string
* `tree`: a defined treename (table-column pair)

If an argument can be of multiple types, you can join them with ` or `. For example, for an argument that can be either a string or a field: `string or field`.

Optional and multi-arity arguments can be specified with special modifiers attached to the end:
* `*`: zero or more
* `?`: zero or one
* `+`: one or more

For example, if you expect one or more string arguments: `string*`. Named arguments are almost always optional, so these would look like: `named:distinct?`. Optional or multi-arity arguments should always be the last parameters.

#### Checking with a function

Lists do not allow you to check dependencies between arguments, so it may be beneficial to define your own `check` function. This function must have four parameters (but not all need to be used):
* `config`: VALVE configuration dictionary
* `table`: the target table that the function will be run in
* `column`: the target column that the function will be run in
* `args`: a list of parsed args passed to the function

The function should return a string error message if any error was found, otherwise, it should return `None`. The custom functions are useful for when you want to validate more than just the structure, for example, if you expect two values that are tables other than the target table:
```python
def validate_foo(config, args, table, column, row_idx, value):
    ...

def check_foo(config, table, column, args):
    i = 1
    for a in args:
        if i == 2:
            return f"foo expects 2 arguments, but {len(args)} were given"
        if a["type"] != "string":
            return f"foo argument {i} must be a string representing a table"
        if a["value"] == table:
            return f"foo argument {i} must not be '{table}'"
        if a["value"] not in config["table_details"]:
            return f"foo argument {i} must be a table in inputs other than '{table}'"
        i += 1

valve.validate(
    "inputs/",
    functions={
        "foo": {
            "usage": "foo(string, string)",
            "check": check_foo,
            "validate": validate_foo
        }
    }
)
```

---

And the checks for the current args:

**any**:`["expression+"]`
**concat**:`["expression or string+"]`
**distinct**:`["expression", "field*"]`
**in**:`["string or field+"]`
**list**:`["string", "expression"]`
**lookup**:`["string", "string, "string"]`
**not**:`["expression"]`
**sub**:`["regex", "expression"]`
**tree**:`["string", "field?", "named:split?"]`
**under**:`["field", "string", "named:direct?"]`