### PR TITLE
Add optional message to config tables

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,8 +16,8 @@ def test_has_ancestors():
 
 
 def test_parsed_to_str():
-    text = "tree(Label, external.Label, split=\", \")"
-    assert valve.parsed_to_str(valve.parse(text)) == text
+    text = "tree(\"Label\", external.Label, split=\", \")"
+    assert valve.parsed_to_str({"datatypes": {}}, valve.parse(text)) == text
 
 
 def test_idx_to_a1():

--- a/valve/valve.py
+++ b/valve/valve.py
@@ -164,7 +164,7 @@ def validate_table(config, table):
                             then_column,
                             row_idx,
                             then_value,
-                            message=rule["message"]
+                            message=rule["message"],
                         )
                         if messages:
                             for m in messages:
@@ -847,13 +847,7 @@ def validate_datatype(config, condition, table, column, row_idx, value):
                     suggestion = re.sub(m.group(1), m.group(2), value)
                 return [
                     error(
-                        config,
-                        table,
-                        column,
-                        row_idx,
-                        message,
-                        level=level,
-                        suggestion=suggestion,
+                        config, table, column, row_idx, message, level=level, suggestion=suggestion,
                     )
                 ]
     return []
@@ -1547,24 +1541,14 @@ def parsed_to_str(condition):
 
 # Builtin datatypes
 default_datatypes = {
-    "blank": {
-        "datatype": "blank",
-        "parent": "",
-        "match": re.compile(r"^$"),
-        "level": "ERROR",
-    },
+    "blank": {"datatype": "blank", "parent": "", "match": re.compile(r"^$"), "level": "ERROR",},
     "datatype_label": {
         "datatype": "datatype_label",
         "parent": "",
         "match": re.compile(r"[A-Za-z][A-Za-z0-9_-]+"),
         "level": "ERROR",
     },
-    "regex": {
-        "datatype": "regex",
-        "parent": "",
-        "match": re.compile(r"^/.+/$"),
-        "level": "ERROR",
-    },
+    "regex": {"datatype": "regex", "parent": "", "match": re.compile(r"^/.+/$"), "level": "ERROR",},
     "regex_sub": {
         "datatype": "regex_sub",
         "parent": "",


### PR DESCRIPTION
This PR adds support for a `message` column in `field.tsv`. The message will replace the default VALVE error messages, which are sometimes unhelpful. You can include the problematic value in the message by including `{value}` in the message. I will update the main VALVE docs as soon as this is approved.