### PR TITLE
fix small bug in validate_sub related to modifier flags in generated regex pattern

### DIFF
--- a/valve/valve.py
+++ b/valve/valve.py
@@ -1175,7 +1175,7 @@ def validate_sub(config, args, table, column, row_idx, value, message=None):
             flags = flags.replace("i", "")
         if flags:
             # a and x flags can be inserted into the pattern
-            pattern = f"?({flags}){pattern}"
+            pattern = f"(?{flags}){pattern}"
 
     if ignore_case:
         value = re.sub(pattern, regex["replace"], value, count=count, flags=re.IGNORECASE)


### PR DESCRIPTION
This is a one-line code change and I don't foresee any problems with it, but I would rather not push it directly to main. Please review and approve this.

For the justification for this change, see: http://www.rexegg.com/regex-disambiguation.html#modifiers